### PR TITLE
update: meta data in navbar now has release date and reformatted last…

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -34,7 +34,7 @@ module.exports = {
     displayAllHeaders: true,
     lastUpdated: 'Last Updated',
     nav: [
-      { text: 'Talk', link: 'https://discord.gg/74GUQDE' },
+      { text: 'Talk to Us', link: 'https://discord.gg/74GUQDE' },
       { text: 'Contribute', link: 'https://github.com/mtgjson' },
       { text: 'Donate', link: 'https://www.paypal.me/Zachhalpern' },
     ],

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -34,7 +34,7 @@ module.exports = {
     displayAllHeaders: true,
     lastUpdated: 'Last Updated',
     nav: [
-      { text: 'Talk to Us', link: 'https://discord.gg/74GUQDE' },
+      { text: 'Talk', link: 'https://discord.gg/74GUQDE' },
       { text: 'Contribute', link: 'https://github.com/mtgjson' },
       { text: 'Donate', link: 'https://www.paypal.me/Zachhalpern' },
     ],

--- a/docs/.vuepress/theme/components/Metadata.vue
+++ b/docs/.vuepress/theme/components/Metadata.vue
@@ -1,0 +1,38 @@
+<template>
+  <div
+    class="meta-data can-hide"
+  >
+    <span
+      ref="versionNumber"
+      class="version-number"
+    >v{{ version.version }}</span>
+    <span
+      class="release-date"
+    >({{ version.date }})</span>
+  </div>
+</template>
+
+<script>
+import Version from '../../public/json/version';
+
+export default {
+  data () {
+    return {
+      version: Version
+    }
+  }
+}
+</script>
+
+<style lang="stylus">
+.meta-data
+  display inline-block
+  margin-left 0.8rem
+  font-size 12px
+  color $textColor
+  position relative
+  .version-number
+    font-weight 600
+  .release-date
+    font-weight normal
+</style>

--- a/docs/.vuepress/theme/components/Metadata.vue
+++ b/docs/.vuepress/theme/components/Metadata.vue
@@ -1,14 +1,14 @@
 <template>
   <div
-    class="meta-data can-hide"
+    class="meta-data"
   >
     <router-link
       class="version-number"
       :to="changelogLink"
     >v{{ metaData.version }}</router-link>
-    <span
+    <!-- <span
       class="release-date"
-    >({{ metaData.date }})</span>
+    >({{ metaData.date }})</span> -->
   </div>
 </template>
 

--- a/docs/.vuepress/theme/components/Metadata.vue
+++ b/docs/.vuepress/theme/components/Metadata.vue
@@ -2,23 +2,31 @@
   <div
     class="meta-data can-hide"
   >
-    <span
-      ref="versionNumber"
+    <router-link
       class="version-number"
-    >v{{ version.version }}</span>
+      :to="changelogLink"
+    >v{{ metaData.version }}</router-link>
     <span
       class="release-date"
-    >({{ version.date }})</span>
+    >({{ metaData.date }})</span>
   </div>
 </template>
 
 <script>
-import Version from '../../public/json/version';
+import MetaData from '../../public/json/version';
 
 export default {
   data () {
     return {
-      version: Version
+      metaData: MetaData
+    }
+  },
+
+  computed: {
+    changelogLink(){
+      const version = this.metaData.version.replace(/\./g, '-');
+      const date = this.metaData.date;
+      return `/changelog/#_${version}-${date}`;
     }
   }
 }

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -14,17 +14,7 @@
       >
     </router-link>
     
-    <div
-      class="meta-data can-hide"
-    >
-      <span
-        ref="versionNumber"
-        class="version-number"
-      >v{{ version.version }}</span>
-      <span
-        class="release-date"
-      >({{ version.date }})</span>
-    </div>
+    <Metadata/>
 
     <div
       class="links"
@@ -43,14 +33,14 @@
 </template>
 
 <script>
-import Version from '../../public/json/version';
+import Metadata from './Metadata.vue';
 import SidebarButton from './SidebarButton.vue'
 import AlgoliaSearchBox from '@AlgoliaSearchBox'
 import SearchBox from '@SearchBox'
 import NavLinks from './NavLinks.vue'
 
 export default {
-  components: { SidebarButton, NavLinks, SearchBox, AlgoliaSearchBox },
+  components: { Metadata, SidebarButton, NavLinks, SearchBox, AlgoliaSearchBox },
 
   data () {
     return {

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -44,8 +44,7 @@ export default {
 
   data () {
     return {
-      linksWrapMaxWidth: null,
-      version: Version
+      linksWrapMaxWidth: null
     }
   },
 

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -10,14 +10,21 @@
         class="logo"
         v-if="$site.themeConfig.logo"
         :src="$withBase($site.themeConfig.logo)"
-        :alt="$siteTitle"
         :title="$siteTitle"
       >
+    </router-link>
+    
+    <div
+      class="meta-data can-hide"
+    >
       <span
         ref="versionNumber"
         class="version-number"
       >v{{ version.version }}</span>
-    </router-link>
+      <span
+        class="release-date"
+      >({{ version.date }})</span>
+    </div>
 
     <div
       class="links"
@@ -97,14 +104,8 @@ $navbar-horizontal-padding = 1.5rem
     display inline-block
   .logo
     height $navbarHeight - 1.4rem
-    min-width $navbarHeight - 1.4rem
-    margin-right 0.8rem
+    width auto
     vertical-align top
-  .version-number
-    font-size 14px
-    font-weight 600
-    color $textColor
-    position relative
   .links
     padding-left 1.5rem
     box-sizing border-box
@@ -122,8 +123,12 @@ $navbar-horizontal-padding = 1.5rem
 @media (max-width: $MQMobile)
   .navbar
     padding-left 4rem
+    .logo
+      height $navbarHeight - 1.8rem
+      vertical-align middle
     .can-hide
       display none
     .links
       padding-left 1.5rem
+            
 </style>

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -69,7 +69,18 @@ export default {
 
   computed: {
     lastUpdated () {
-      return this.$page.lastUpdated
+      const def = this.$page.lastUpdated;
+      // Format for standard computer date and drop exact time
+      const unformattedDate = def.split(',')[0].split('/');
+      const unformattedMonth = unformattedDate[0];
+      const unformattedDay = unformattedDate[1];
+      const formattedYear = unformattedDate[2];
+      // Add padding
+      const formattedMonth = unformattedMonth.length < 2? '0' + unformattedMonth : unformattedMonth;
+      const formattedDay = unformattedDay.length < 2? '0' + unformattedDay : unformattedDay;
+      const formattedDate = `${formattedYear}-${formattedMonth}-${formattedDay}`;
+      // Return standard date
+      return formattedDate;
     },
 
     lastUpdatedText () {

--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -1,16 +1,6 @@
 <template>
   <aside class="sidebar">
-    <div
-      class="meta-data can-hide"
-    >
-      <span
-        ref="versionNumber"
-        class="version-number"
-      >v{{ version.version }}</span>
-      <span
-        class="release-date"
-      >({{ version.date }})</span>
-    </div>
+    <Metadata/>
     <NavLinks/>
     <slot name="top"/>
     <SidebarLinks :depth="0" :items="items"/>
@@ -19,6 +9,7 @@
 </template>
 
 <script>
+import Metadata from './Metadata.vue';
 import Version from '../../public/json/version';
 import SidebarLinks from './SidebarLinks.vue'
 import NavLinks from './NavLinks.vue'
@@ -26,7 +17,7 @@ import NavLinks from './NavLinks.vue'
 export default {
   name: 'Sidebar',
 
-  components: { SidebarLinks, NavLinks },
+  components: { Metadata, SidebarLinks, NavLinks },
 
   props: ['items'],
 

--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -1,5 +1,16 @@
 <template>
   <aside class="sidebar">
+    <div
+      class="meta-data can-hide"
+    >
+      <span
+        ref="versionNumber"
+        class="version-number"
+      >v{{ version.version }}</span>
+      <span
+        class="release-date"
+      >({{ version.date }})</span>
+    </div>
     <NavLinks/>
     <slot name="top"/>
     <SidebarLinks :depth="0" :items="items"/>
@@ -8,6 +19,7 @@
 </template>
 
 <script>
+import Version from '../../public/json/version';
 import SidebarLinks from './SidebarLinks.vue'
 import NavLinks from './NavLinks.vue'
 
@@ -16,7 +28,13 @@ export default {
 
   components: { SidebarLinks, NavLinks },
 
-  props: ['items']
+  props: ['items'],
+
+  data(){
+    return {
+      version: Version
+    }
+  }
 }
 </script>
 
@@ -28,6 +46,9 @@ export default {
     list-style-type none
   a
     display inline-block
+  .meta-data
+    margin-left 1.5rem
+    margin-top 0.75rem
   .nav-links
     display none
     border-bottom 1px solid $borderColor
@@ -56,4 +77,10 @@ export default {
         top calc(1rem - 2px)
     & > .sidebar-links
       padding 1rem 0
+
+@media (min-width: $MQMobile)
+  .sidebar
+    .meta-data
+      &.can-hide
+        display none
 </style>

--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -1,6 +1,5 @@
 <template>
   <aside class="sidebar">
-    <Metadata/>
     <NavLinks/>
     <slot name="top"/>
     <SidebarLinks :depth="0" :items="items"/>
@@ -9,7 +8,6 @@
 </template>
 
 <script>
-import Metadata from './Metadata.vue';
 import Version from '../../public/json/version';
 import SidebarLinks from './SidebarLinks.vue'
 import NavLinks from './NavLinks.vue'
@@ -17,15 +15,9 @@ import NavLinks from './NavLinks.vue'
 export default {
   name: 'Sidebar',
 
-  components: { Metadata, SidebarLinks, NavLinks },
+  components: { SidebarLinks, NavLinks },
 
   props: ['items'],
-
-  data(){
-    return {
-      version: Version
-    }
-  }
 }
 </script>
 
@@ -37,9 +29,6 @@ export default {
     list-style-type none
   a
     display inline-block
-  .meta-data
-    margin-left 1.5rem
-    margin-top 0.75rem
   .nav-links
     display none
     border-bottom 1px solid $borderColor
@@ -68,10 +57,4 @@ export default {
         top calc(1rem - 2px)
     & > .sidebar-links
       padding 1rem 0
-
-@media (min-width: $MQMobile)
-  .sidebar
-    .meta-data
-      &.can-hide
-        display none
 </style>

--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -164,6 +164,18 @@ th, td
   border 1px solid #dfe2e5
   padding .6em 1em
 
+
+.meta-data
+  display inline-block
+  margin-left 0.8rem
+  font-size 12px
+  color $textColor
+  position relative
+  .version-number
+    font-weight 600
+  .release-date
+    font-weight normal
+
 .theme-container
   &.sidebar-open
     .sidebar-mask

--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -164,18 +164,6 @@ th, td
   border 1px solid #dfe2e5
   padding .6em 1em
 
-
-.meta-data
-  display inline-block
-  margin-left 0.8rem
-  font-size 12px
-  color $textColor
-  position relative
-  .version-number
-    font-weight 600
-  .release-date
-    font-weight normal
-
 .theme-container
   &.sidebar-open
     .sidebar-mask
@@ -186,7 +174,6 @@ th, td
         padding-top 0
     .sidebar
       top 0
-
 
 @media (min-width: ($MQMobile + 1px))
   .theme-container.no-sidebar

--- a/docs/.vuepress/theme/styles/wrapper.styl
+++ b/docs/.vuepress/theme/styles/wrapper.styl
@@ -1,9 +1,5 @@
 $wrapper
   max-width $contentWidth
   margin 0 auto
-  padding 2rem 2.5rem
-  @media (max-width: $MQNarrow)
-    padding 2rem
-  @media (max-width: $MQMobileNarrow)
-    padding 1.5rem
+  padding 2rem 25px
 


### PR DESCRIPTION
# Changelog
- Added date to meta data in navbar
- Added meta data to mobile sidebar to show meta data when not enough room
- Reformatted last updated time at bottom of pages to match the standard time used in meta data
- Changed talk to us button text to take up less room
- Removed unnecessary alt text for logo

Close #80 Close #79 