### PR TITLE
issue/98 | update: documentation changes. see changelog in PR.

### DIFF
--- a/docs/.vuepress/components/GenerateSetDownloads.vue
+++ b/docs/.vuepress/components/GenerateSetDownloads.vue
@@ -16,14 +16,15 @@
       .download-item
         .download-wrap
           .img-wrap
-            div(v-if="set.parentCode" :class="`ss ss-${set.parentCode.toLowerCase()}`")
+            div(v-if="set.keyruneCode" :class="`ss ss-${set.keyruneCode.toLowerCase()}`")
+            div(v-else-if="set.parentCode" :class="`ss ss-${set.parentCode.toLowerCase()}`")
             div(v-else :class="`ss ss-${set.code.toLowerCase()}`")
           .txt-wrap
             h3(:id="set.code") {{ set.name }}
             small Set Code: 
               span {{ set.code }}
             small Set Type: 
-              span {{ set.type.replace('_', ' ') }}
+              span.type {{ set.type }}
             small Release Date: 
               span {{ set.releaseDate }}
           .dl-wrap
@@ -46,7 +47,7 @@ export default {
     };
   },
   beforeMount(){
-    this.defaultSets = this.sorter('name', this.defaultSets);
+    this.defaultSets = this.sorter('releaseDate:true', this.defaultSets);
   },
   computed: {
     sets() {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -32,7 +32,8 @@ module.exports = {
   themeConfig: {
     searchMaxSuggestions: 20,
     displayAllHeaders: true,
-    lastUpdated: 'Last Updated',
+    // Currently does not render on all pages
+    // lastUpdated: 'Last Updated',
     nav: [
       { text: 'Talk to Us', link: 'https://discord.gg/74GUQDE' },
       { text: 'Contribute', link: 'https://github.com/mtgjson' },

--- a/docs/.vuepress/public/schemas/Decks.schema.json
+++ b/docs/.vuepress/public/schemas/Decks.schema.json
@@ -1,22 +1,22 @@
 {
   "fileName": {
     "type": "string",
-    "example": "AbzanSiege",
+    "example": "\"AbzanSiege\"",
     "description": "File name for the deck."
   },
   "name": {
     "type": "string",
-    "example": "Abzan Siege",
+    "example": "\"Abzan Siege\"",
     "description": "Actual name of the deck."
   },
   "code": {
     "type": "string",
-    "example": "KTK",
+    "example": "\"KTK\"",
     "description": "Set code for the deck."
   },
   "releaseDate": {
     "type": "string",
     "example": "\"2000-01-01\"",
-    "description": "Release date of the deck. (Coming soon)"
+    "description": "Release date of the deck."
   }
 }

--- a/docs/.vuepress/public/schemas/Set.schema.json
+++ b/docs/.vuepress/public/schemas/Set.schema.json
@@ -16,7 +16,7 @@
   },
   "cards": {
     "type": "array(object)",
-    "example": " [{{card}}] ",
+    "example": "{{card}}",
     "description": "List of cards in this set."
   },
   "code": {
@@ -38,6 +38,21 @@
     "type": "boolean",
     "example": "false",
     "description": "Set available online only. Can be true or false. (If false, it is usually omitted.)"
+  },
+  "keyruneCode": {
+    "type": "string",
+    "example": "\"KTK\"",
+    "description": "The matching keyrune code for keyrune.css image icons."
+  },
+  "mcmName": {
+    "type": "string",
+    "example": "\"Ravnica Allegiance\"",
+    "description": "The Magic Card Market set name."
+  },
+  "mcmId": {
+    "type": "integer",
+    "example": "2411",
+    "description": "The Magic Card Market set id."
   },
   "meta": {
     "type": "object(string: string)",
@@ -66,17 +81,22 @@
   },
   "tokens": {
     "type": "array(object)",
-    "example": "[{{token}}]",
-    "description": "See the {{token}} structure."
+    "example": "{{token}}",
+    "description": "Tokens available to the set. See the {{token}} structure."
   },
   "totalSetSize": {
     "type": "integer",
     "example": "273",
     "description": "Total number of cards in the set, including promos and related supplemental products."
   },
+  "translations": {
+    "type": "object(string: string)",
+    "example": "{{translations}}",
+    "description": "Translated set name by language. See the {{translations}} structure."
+  },
   "type": {
     "type": "string",
     "example": "\"expansion\"",
-    "description": "See {{types}} examples."
+    "description": "See {{type}} examples."
   }
 }

--- a/docs/.vuepress/public/schemas/Translations.schema.json
+++ b/docs/.vuepress/public/schemas/Translations.schema.json
@@ -1,0 +1,52 @@
+{
+  "\"Chinese Simplified\"": {
+    "type": "string",
+    "example": "\"\u6548\u5fe0\u62c9\u5c3c\u5361\"",
+    "description": "Translation in Chinese Simplified."
+  },
+  "\"Chinese Traditional\"": {
+    "type": "string",
+    "example": "\"\u6548\u5fe0\u62c9\u5c3c\u5361\"",
+    "description": "Translation in Chinese Traditional."
+  },
+  "\"French\"": {
+    "type": "string",
+    "example": "\"L'all\u00e9geance de Ravnica\"",
+    "description": "Translated in French."
+  },
+  "\"German\"": {
+    "type": "string",
+    "example": "\"Ravnicas Treue\"",
+    "description": "Translated in German."
+  },
+  "\"Italian\"": {
+    "type": "string",
+    "example": "\"Fedelt\u00e0 di Ravnica\"",
+    "description": "Translated in Italian."
+  },
+  "\"Japanese\"": {
+    "type": "string",
+    "example": "\"\u300e\u30e9\u30f4\u30cb\u30ab\u306e\u732e\u8eab\u300f\"",
+    "description": "Translated in Japanese."
+  },
+  "\"Korean\"": {
+    "type": "string",
+    "example": "\"\ub77c\ube0c\ub2c8\uce74\uc758 \ucda9\uc131\"",
+    "description": "Translated in Korean."
+  },
+  "\"Portuguese (Brazil)\"": {
+    "type": "string",
+    "example": "\"Lealdade em Ravnica\"",
+    "description": "Translated in Portuguese (Brazil)."
+  },
+  "\"Russian\"": {
+    "type": "string",
+    "example": "\"\u00ab\u0412\u044b\u0431\u043e\u0440 \u0420\u0430\u0432\u043d\u0438\u043a\u0438\u00bb\"",
+    "description": "Translated in Russian."
+  },
+  "\"Spanish\"": {
+    "type": "string",
+    "example": "\"La lealtad de R\u00e1vnica\"",
+    "description": "Translated in Spanish."
+  }
+}

--- a/docs/.vuepress/scripts/Landcycle.js
+++ b/docs/.vuepress/scripts/Landcycle.js
@@ -11,6 +11,7 @@ export default class {
     this.className = 'Landcycle';
     this.lands = [
       '{{compiled-list}}',
+      '{{translations}}',
       '{{frame-effect}}',
       '{{foreign-data}}',
       '{{card-types}}',

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -69,17 +69,23 @@ export default {
 
   computed: {
     lastUpdated () {
-      const def = this.$page.lastUpdated;
-      // Format for standard computer date and drop exact time
-      const unformattedDate = def.split(',')[0].split('/');
-      const unformattedMonth = unformattedDate[0];
-      const unformattedDay = unformattedDate[1];
-      const formattedYear = unformattedDate[2];
-      // Add padding
-      const formattedMonth = unformattedMonth.length < 2? '0' + unformattedMonth : unformattedMonth;
-      const formattedDay = unformattedDay.length < 2? '0' + unformattedDay : unformattedDay;
-      const formattedDate = `${formattedYear}-${formattedMonth}-${formattedDay}`;
-      // Return standard date
+      const date = this.$page.lastUpdated;
+      let formattedDate = '';
+      
+      if(date){
+        // Format for standard computer date and drop exact time
+        const unformattedDate = date.split(',')[0].split('/');
+        const unformattedMonth = unformattedDate[0];
+        const unformattedDay = unformattedDate[1];
+        const formattedYear = unformattedDate[2];
+        // Add padding
+        const formattedMonth = unformattedMonth.length < 2? '0' + unformattedMonth : unformattedMonth;
+        const formattedDay = unformattedDay.length < 2? '0' + unformattedDay : unformattedDay;
+        
+        formattedDate = `${formattedYear}-${formattedMonth}-${formattedDay}`;
+        
+      }
+      
       return formattedDate;
     },
 

--- a/docs/.vuepress/theme/styles/download.styl
+++ b/docs/.vuepress/theme/styles/download.styl
@@ -5,8 +5,8 @@
   
   h3 {
     font-size: 16px;
-    line-height: 2em;
-    margin: 0;
+    line-height: 1em;
+    margin: 0 0 10px;
   }
 
   .sorting-options {
@@ -28,7 +28,6 @@
     }
   }
 
-
   .download-table {
     border: 1px solid #eaecef;
     box-sizing: border-box;
@@ -49,7 +48,7 @@
       flex: 0 0 100%;
 
       .download-wrap {
-        padding: 10px 20px 20px;
+        padding: 15px 20px 20px;
         display: flex;
         flex-wrap: wrap;
         align-items: center;
@@ -93,6 +92,10 @@
             span {
               font-weight: normal;
               text-transform: capitalize;
+
+              &.type {
+                text-transform: none;
+              }
             }
           }
         }

--- a/docs/structures/token/README.md
+++ b/docs/structures/token/README.md
@@ -22,6 +22,10 @@
 > Parent property type: `array(anonymous object)`  
 > Property type: `string`  
 
+::: warning
+As of v4.3.2 all token `uuid` values have been re-uniqueified. This will be the last change to `uuid` as they are now stable.
+:::
+
 ### Structure
 
 <GenerateTable/>

--- a/docs/structures/translations/README.md
+++ b/docs/structures/translations/README.md
@@ -1,0 +1,27 @@
+---
+{
+  "title": "translations",
+  "schema": "Translations",
+  "meta": [
+    {
+      "name": "description",
+      "content": "translations data structure for MTGJSON.",
+    },
+    {
+      "name": "keywords",
+      "content": "mtg, magic: the gathering, mtgjson, json, translations",
+    }
+  ]
+}
+---
+
+# Translations
+
+> Parent structure: [set](../set)  
+> Parent property: `translations`  
+> Parent property type: `object(string: string)`  
+> Property type: `string`  
+
+### Structure
+
+<GenerateTable/>


### PR DESCRIPTION
## Changelog
- Added documentation changes from #98
- Fix sets initial render from sorting on the wrong selected option
- Added Translations schema and documentation page
- Fix Set schema's `type` documentation reference
- Bug discovered #100: Last updated does not render on all pages. But maybe we dont need this as it can be confusing to the user if some pages have updates and other don't. Feature has been disabled.
- Fixed some css margins for the download items
- Normalized the set type to show the data value instead of a pretty value

Close #98 