### PR TITLE
remove: warning for new uuid's on tokens.

### DIFF
--- a/docs/structures/token/README.md
+++ b/docs/structures/token/README.md
@@ -22,10 +22,6 @@
 > Parent property type: `array(anonymous object)`  
 > Property type: `string`  
 
-::: warning
-As of v4.3.2 all token `uuid` values have been re-uniqueified. This will be the last change to `uuid` as they are now stable.
-:::
-
 ### Structure
 
 <GenerateTable/>


### PR DESCRIPTION
## Changelog
- Remove UUID warning on tokens for 4.3.3