### PR TITLE
issue/141 | add: parentCode key was missing from set schema.

### DIFF
--- a/docs/.vuepress/public/schemas/Set.schema.json
+++ b/docs/.vuepress/public/schemas/Set.schema.json
@@ -69,6 +69,11 @@
     "example": "\"Ravnica Allegiance\"",
     "description": "Name of the set."
   },
+  "parentCode": {
+    "type": "string",
+    "example": "\"RNA\"",
+    "description": "The parent set code for set variations like promotions, guild kits, etc."
+  },
   "releaseDate": {
     "type": "string",
     "example": "\"2019-01-25\"",


### PR DESCRIPTION
## Changelog
- Added parentCode key for set schema

Close #141 