### PR TITLE
add mtgstocks id and prices schema and documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ We use the `.schema.json` format for documentation on structures. In some IDE's 
 
 ## Landcycle
 
-Landcycle is a JS class that allows JSON to take mustache variables such as `{{link:variable}}` (creating an anchor link) or `{{code:variable}}` (creating an inline-code style) and then intercepts the JSON in Vue to hydrate the data in to data of your choosing. On the website we use this to change data structures in to anchor tags that link to other documentation.
+Landcycle is a JS class that allows JSON to take mustache variables such as `{{link:variable}}` (creating an internal link), `{{external:display-text$url}}` (creating an external link) and `{{code:variable}}` (creating an inline-code style) and then intercepts the JSON in Vue to hydrate the data in to data of your choosing. On the website we use this to change data structures in to anchor tags that link to other documentation.

--- a/docs/.vuepress/public/schemas/AllCards.schema.json
+++ b/docs/.vuepress/public/schemas/AllCards.schema.json
@@ -69,6 +69,11 @@
     "example": "\"{3}{W}{W}\"",
     "description": "Mana cost of the card."
   },
+  "mtgstocksId": {
+    "type": "integer",
+    "example": "40272",
+    "description": "mtgstocks.com card id."
+  },
   "name": {
     "type": "string",
     "example": "\"Angel of Grace\"",
@@ -83,6 +88,11 @@
     "type": "string",
     "example": "\"5\"",
     "description": "Power of the creature."
+  },
+  "prices": {
+    "type": "object(string: object)",
+    "example": "{{link:prices}}",
+    "description": "See the {{link:prices}} structure."
   },
   "printings": {
     "type": "array(string)",

--- a/docs/.vuepress/public/schemas/Card.schema.json
+++ b/docs/.vuepress/public/schemas/Card.schema.json
@@ -144,6 +144,11 @@
     "example": "\"Angel of Grace\"",
     "description": "The Magic Card Market card name."
   },
+  "mtgstocksId": {
+    "type": "integer",
+    "example": "40272",
+    "description": "mtgstocks.com card id."
+  },
   "multiverseId": {
     "type": "integer",
     "example": "457145",
@@ -178,6 +183,11 @@
     "type": "string",
     "example": "\"5\"",
     "description": "Power of the creature."
+  },
+  "prices": {
+    "type": "object(string: object)",
+    "example": "{{link:prices}}",
+    "description": "See the {{link:prices}} structure."
   },
   "printings": {
     "type": "array(string)",

--- a/docs/.vuepress/public/schemas/Prices.schema.json
+++ b/docs/.vuepress/public/schemas/Prices.schema.json
@@ -2,6 +2,6 @@
   "paper": {
     "type": "object(string: float)",
     "example": "\"2019-04-28\": 0.25",
-    "description": "Paper format prices of a card. Courtesy of mtgstocks."
+    "description": "Paper format prices of a card. Courtesy of {{external:mtgstocks.com}}."
   }
 }

--- a/docs/.vuepress/public/schemas/Prices.schema.json
+++ b/docs/.vuepress/public/schemas/Prices.schema.json
@@ -2,6 +2,6 @@
   "paper": {
     "type": "object(string: float)",
     "example": "\"2019-04-28\": 0.25",
-    "description": "Paper format prices of a card."
+    "description": "Paper format prices of a card. Courtesy of mtgstocks."
   }
 }

--- a/docs/.vuepress/public/schemas/Prices.schema.json
+++ b/docs/.vuepress/public/schemas/Prices.schema.json
@@ -1,0 +1,7 @@
+{
+  "paper": {
+    "type": "object(string: float)",
+    "example": "\"2019-04-28\": 0.25",
+    "description": "Paper format prices of a card."
+  }
+}

--- a/docs/.vuepress/public/schemas/Prices.schema.json
+++ b/docs/.vuepress/public/schemas/Prices.schema.json
@@ -2,6 +2,6 @@
   "paper": {
     "type": "object(string: float)",
     "example": "\"2019-04-28\": 0.25",
-    "description": "Paper format prices of a card. Courtesy of {{external:mtgstocks.com$https://www.mtgstocks.com?utm_campaign=mtgjson&utm_medium=mtgjson&utm_source=mtgjson}}."
+    "description": "Paper format prices of a card. Courtesy of {{external:mtgstocks$https://www.mtgstocks.com?utm_campaign=mtgjson&utm_medium=mtgjson&utm_source=mtgjson}}."
   }
 }

--- a/docs/.vuepress/public/schemas/Prices.schema.json
+++ b/docs/.vuepress/public/schemas/Prices.schema.json
@@ -2,6 +2,6 @@
   "paper": {
     "type": "object(string: float)",
     "example": "\"2019-04-28\": 0.25",
-    "description": "Paper format prices of a card. Courtesy of {{external:mtgstocks.com}}."
+    "description": "Paper format prices of a card. Courtesy of {{external:mtgstocks.com$https://www.mtgstocks.com?utm_campaign=mtgjson&utm_medium=mtgjson&utm_source=mtgjson}}."
   }
 }

--- a/docs/.vuepress/scripts/Landcycle.js
+++ b/docs/.vuepress/scripts/Landcycle.js
@@ -1,6 +1,9 @@
 /**
  * @Type Class
  * @constructor @arguments
+ * 
+ * The structure of a mustache is as so:
+ * {{tag:first$second}}
  * */
 
 let logger = null;
@@ -30,7 +33,11 @@ export default class {
 
     let value = card.match(/{{(.*?)}}/)[1];
     let tag = value.split(':')[0];
-    let text = value.split(':')[1];
+    /**
+     * @todo rename these later
+     */
+    let text = card.match(/:(.*?)\$/)[1];
+    let url = card.match(/\$(.*?)}}/)[1] || text;
     let plane = '';
     let land = '';
 
@@ -51,7 +58,7 @@ export default class {
         break;
 
       case 'external':
-        land = `<a href="http://${text}" target="_blank">${text}</a>`;
+        land = `<a href="${url}" target="_blank">${text}</a>`;
         break;
 
       case 'link':

--- a/docs/.vuepress/scripts/Landcycle.js
+++ b/docs/.vuepress/scripts/Landcycle.js
@@ -50,6 +50,10 @@ export default class {
         land = `<code>${text}</code>`;
         break;
 
+      case 'external':
+        land = `<a href="http://${text}" target="_blank">${text}</a>`;
+        break;
+
       case 'link':
       default:
         land = `<a class="code-link" href="/${plane}/${text}" />${this.faceUp(

--- a/docs/.vuepress/scripts/Landcycle.js
+++ b/docs/.vuepress/scripts/Landcycle.js
@@ -58,7 +58,7 @@ export default class {
         break;
 
       case 'external':
-        land = `<a href="${url}" target="_blank">${text}</a>`;
+        land = `<a class="code-link" href="${url}" target="_blank">${text}</a>`;
         break;
 
       case 'link':

--- a/docs/structures/prices/README.md
+++ b/docs/structures/prices/README.md
@@ -22,7 +22,7 @@
 
 Prices is a structure defining an object of card prices based on date.
 
-> Parent structure: [card](../card), [AllCards](../../all-cards)  
+> Parent structure: [card](../card), [AllCards](../../files/all-cards)  
 > Parent property: `prices`  
 > Parent property type: `object(anonymous object)`  
 > Property type: `object`  

--- a/docs/structures/prices/README.md
+++ b/docs/structures/prices/README.md
@@ -1,0 +1,32 @@
+---
+{
+  "title": "prices",
+  "schema": "Prices",
+  "meta": [
+    {
+      "name": "description",
+      "content": "prices data structure for MTGJSON.",
+    },
+    {
+      "name": "keywords",
+      "content": "mtg, magic: the gathering, mtgjson, json, prices",
+    }
+  ],
+  "feed": {
+    "enable": "true"
+  }
+}
+---
+
+# Prices
+
+Prices is a structure defining an object of card prices based on date.
+
+> Parent structure: [card](../card), [AllCards](../../all-cards)  
+> Parent property: `prices`  
+> Parent property type: `object(anonymous object)`  
+> Property type: `object`  
+
+### Structure
+
+<GenerateTable/>


### PR DESCRIPTION
## Changelog
- Add mtgstocks.com id and prices schema to card objects.

Close #156 