### PR TITLE
fix hyphens on mobile

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,13 +19,13 @@
 
 ## Our Mission
 
-MTGJSON is an open‐source project that catalogues all Magic cards in a portable format. A dedicated group of fans maintains and supplies data for a variety of projects and sites in the community.
+MTGJSON is an open-source project that catalogues all Magic cards in a portable format. A dedicated group of fans maintains and supplies data for a variety of projects and sites in the community.
 
 ## The Team
 
 ::: tip Zach - Lead Developer &amp; Maintainer
 ![avatar](/images/avatar-zach.jpg "Zach")
-Zach is a 22‐year old hippo fanatic who loves playing with big data and giving back to the community in unique ways. He has worked on MTGJSON since 2016, and has led the design and development of version 4. His work can also be seen heavily in the open‐source Cockatrice game client.<br/><br/>
+Zach is a 22-year old hippo fanatic who loves playing with big data and giving back to the community in unique ways. He has worked on MTGJSON since 2016, and has led the design and development of version 4. His work can also be seen heavily in the open-source Cockatrice game client.<br/><br/>
 <em>All inquires about MTGJSON can be sent to <a href="mailto:zach@mtgjson.com">zach@mtgjson.com</a></em>
 :::
 


### PR DESCRIPTION
On mobile (Safari iOS 12.2) hyphens are not always correctly displayed.

e.g. on the About startpage:
- `open_source` (mission)
- `22_year`
- `open_source` (team/zach)

Interestingly `open-source` is displayed correctly at team/eric.
Copy pasted the working one to the other locations.