### PR TITLE
remove domain code from names

### DIFF
--- a/docs/.vuepress/public/resources/supporters.json
+++ b/docs/.vuepress/public/resources/supporters.json
@@ -230,7 +230,7 @@
       "link": "https://cardcodex.com"
     },
     {
-      "name": "DeckList.org",
+      "name": "DeckList",
       "link": "https://decklist.org/"
     },
     {
@@ -238,7 +238,7 @@
       "link": "https://github.com/Didero/DideRobot"
     },
     {
-      "name": "FlavorTexts.com",
+      "name": "FlavorTexts",
       "link": "https://flavortexts.com"
     },
     {


### PR DESCRIPTION
As long as the domain code is not part of the name or needed for distinguishing a service it can be removed. We don't use it for other pages too.