### PR TITLE
issue/359 | remove: image optimization from the build process for now.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   },
   "scripts": {
     "dev": "vuepress dev docs",
-    "build": "yarn optimize-images && vuepress build docs && yarn generate-version-atom",
+    "build": "vuepress build docs && yarn generate-version-atom",
     "purge": "rm -rf node_modules && yarn cache clean",
     "test": "yarn lint && jest --coverage --coverageDirectory='__coverage__'",
-    "test:full": "yarn test && yarn build && git add .",
+    "test:full": "yarn test && yarn build",
     "lint": "eslint --fix --ext .js,.vue docs/.vuepress",
     "regenerate-schema": "node ./utils/regenerate-schema.js",
     "generate-version-atom": "node ./utils/generate-version-atom.js",


### PR DESCRIPTION
Should still be run on occasion to keep the site load times down