### PR TITLE
docs: fix typo in all-prices

### DIFF
--- a/docs/abstract-models/all-prices/README.md
+++ b/docs/abstract-models/all-prices/README.md
@@ -22,7 +22,7 @@
 
 # All Prices
 
-The All Prices abstract Data Model describes a list of card prices based on MTGJSON a Card UUID.
+The All Prices abstract Data Model describes a list of card prices based on a MTGJSON Card UUID.
 
 **Parent file:** [AllPrices](/downloads/all-files/#allprices)  
 **Parent property:** `data`


### PR DESCRIPTION
The incorrect word ordering can be seen at https://mtgjson.com/abstract-models/all-prices/