### PR TITLE
ni/fix_docs: fix otherFaceIds documentation

### DIFF
--- a/docs/data-models/card-deck/README.md
+++ b/docs/data-models/card-deck/README.md
@@ -430,8 +430,9 @@ The Card (Deck) Data Model describes the properties and values of a single card 
 > ### otherFaceIds  
 > A list of card UUID's to this card's counterparts, such as transformed or melded faces.
 >
-> - **Type:** `array[] || array[string]`  
+> - **Type:** `array[string]`  
 > - **Introduced:** `v4.6.1`
+> - **Tags:** <i class="optional">optional</i>  
 
 > ### power  
 > The power of the card.  

--- a/docs/data-models/card-set/README.md
+++ b/docs/data-models/card-set/README.md
@@ -410,8 +410,9 @@ The Card (Set) Data Model describes the properties of a single card in a set.
 > ### otherFaceIds  
 > A list of card UUID's to this card's counterparts, such as transformed or melded faces.
 >
-> - **Type:** `array[] || array[string]`  
+> - **Type:** `array[string]`  
 > - **Introduced:** `v4.6.1`
+> - **Tags:** <i class="optional">optional</i>  
 
 > ### power  
 > The power of the card.  

--- a/docs/data-models/card-token/README.md
+++ b/docs/data-models/card-token/README.md
@@ -229,8 +229,9 @@ The Card (Token) Data Model describes the properties and values of a single toke
 > ### otherFaceIds  
 > A list of card UUID's to this card's counterparts, such as transformed or melded faces.
 >
-> - **Type:** `array[] || array[string]`  
+> - **Type:** `array[string]`  
 > - **Introduced:** `v4.6.1`
+> - **Tags:** <i class="optional">optional</i>  
 
 > ### power  
 > The power of the card.  


### PR DESCRIPTION
- The property `otherFaceIds` doesn't exist in every card, so I added the tag `optional`
- The property `otherFaceIds` is never an empty list, so I changed the type accordingly