### PR TITLE
ni/fix_docs: fix frameEffects documentation

### DIFF
--- a/docs/data-models/card-deck/README.md
+++ b/docs/data-models/card-deck/README.md
@@ -181,9 +181,10 @@ The Card (Deck) Data Model describes the properties and values of a single card 
 > ### frameEffects  
 > The visual frame effects.  
 >
-> - **Type:** `array[] || array[string]`
+> - **Type:** `array[string]`
 > - <ExampleField type='frameEffects'/>
 > - **Introduced:** `v4.6.0`
+> - **Tags:** <i class="optional">optional</i>  
 
 > ### frameVersion  
 > The version of the card frame style.  

--- a/docs/data-models/card-set/README.md
+++ b/docs/data-models/card-set/README.md
@@ -167,9 +167,10 @@ The Card (Set) Data Model describes the properties of a single card in a set.
 > ### frameEffects  
 > The visual frame effects.  
 >
-> - **Type:** `array[] || array[string]`
+> - **Type:** `array[string]`
 > - <ExampleField type='frameEffects'/>
 > - **Introduced:** `v4.6.0`
+> - **Tags:** <i class="optional">optional</i>  
 
 > ### frameVersion  
 > The version of the card frame style.  

--- a/docs/data-models/card-token/README.md
+++ b/docs/data-models/card-token/README.md
@@ -126,9 +126,10 @@ The Card (Token) Data Model describes the properties and values of a single toke
 > ### frameEffects  
 > The visual frame effects.  
 >
-> - **Type:** `array[] || array[string]`
+> - **Type:** `array[string]`
 > - <ExampleField type='frameEffects'/>
 > - **Introduced:** `v4.6.0`
+> - **Tags:** <i class="optional">optional</i>  
 
 > ### frameVersion  
 > The version of the card frame style.  


### PR DESCRIPTION
- The property `frameEffects` doesn't exist in every card, so I added the tag `optional`
- The property `frameEffects` is never an empty list, so I changed the type accordingly