### PR TITLE
Removed extra . on FAQ

### DIFF
--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -78,7 +78,7 @@ Here are some common questions about MTGJSON data and services.
 > // Assuming you have the scryfallId property available in your code...
 > const fileFace: string = 'front';
 > const fileType: string = 'large';
-> const fileFormat: string = '.jpg';
+> const fileFormat: string = 'jpg';
 > const fileName: string = scryfallId;
 > const dir1: string = fileName.charAt(0);
 > const dir2: string = fileName.charAt(1);


### PR DESCRIPTION
There was an extra . in the FAQ section that provides a code snippet for retrieving Scryfall images based on the Scryfall id