### PR TITLE
fix(type): Update `BoosterConfig.boosters` type docs

### DIFF
--- a/docs/data-models/booster/booster-config/index.md
+++ b/docs/data-models/booster/booster-config/index.md
@@ -36,7 +36,7 @@ The Booster Config Data Model describes the properties of how a [Set](/data-mode
 >
 > The booster packs configurations. See the [Booster (Pack)](/data-models/booster/booster-pack/) Data Model.
 >
-> - **Type:** `Record<string, BoosterPack[]>`
+> - **Type:** `BoosterPack[]`
 > - **Introduced:** `v5.2.2`
 
 > ### boostersTotalWeight


### PR DESCRIPTION
## Changes
- Updated `BoosterConfig.boosters` field from Record to a List to bring in line with current schema

## Notes
- Source provider: [taw/magic-sealed-data](https://github.com/taw/magic-sealed-data?tab=readme-ov-file#boosters-field)
- See `booster.arena.boosters` field of this set to compare: [mtgjson/WOE](https://mtgjson.com/api/v5/WOE.json)