### PR TITLE
Small Typo, Update Docs

### DIFF
--- a/docs/.vitepress/theme/components/Home.vue
+++ b/docs/.vitepress/theme/components/Home.vue
@@ -125,7 +125,7 @@ main.home
             img.lazy(
               :data-src="contributor.avatar",
               :alt="`${contributor.username}'s avatar`",
-              :title="`${contributor.username}'s avatar'`",
+              :title="`${contributor.username}'s avatar`",
               width="100",
               height="100"
             )

--- a/docs/data-models/booster/booster-config/index.md
+++ b/docs/data-models/booster/booster-config/index.md
@@ -59,3 +59,10 @@ The Booster Config Data Model describes the properties of how a [Set](/data-mode
 >
 > - **Type:** `Record<string, BoosterSheet>`
 > - **Introduced:** `v5.2.2`
+
+> ### sourceSetCodes
+>
+> The set codes with which cards in this booster are selected from.
+>
+> - **Type:** `string[]`
+> - **Introduced:** `v5.2.2`


### PR DESCRIPTION
Fixed a small typo in an image's alt attribute.

This PR should also close out #659 