### PR TITLE
Show "No results found." instead of an endless loading message

### DIFF
--- a/docs/.vitepress/theme/components/DownloadList.vue
+++ b/docs/.vitepress/theme/components/DownloadList.vue
@@ -10,8 +10,10 @@
     @canShowButton="toggleShowMore",
     @canShowAllButton="toggleShowAll"
   )
-  div(v-if="resultsTotalLength === 0")
+  div(v-if="isLoading")
     p.results-message Loading...
+  div(v-else-if="resultsTotalLength === 0")
+    p.results-message No results found.
   div(v-else)
     p.results-message Showing {{ resultsLength }} of {{ resultsTotalLength }} Results
     blockquote(v-for="(item, key) in list", :key="key")
@@ -81,7 +83,7 @@
   </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useStore } from '../store';
 import DownloadNativeSelect from './DownloadNativeSelect.vue';
 import DownloadSorter from './DownloadSorter.vue';
@@ -109,6 +111,7 @@ const sortKey = ref<string>('releaseDate:true');
 const sortedList = ref<TList[]>([]);
 
 const defaultList = computed<TList[]>((): TList[] => store[props.file]);
+const isLoading = computed<boolean>((): boolean => defaultList.value.length === 0);
 const listFilters = computed<string[]>((): string[] =>
   Array.from(new Set(defaultList.value.map((cur: TList) => cur.type)))
 );
@@ -159,10 +162,16 @@ const toggleShowAll = (canShow: boolean): void => {
   canLoadAll.value = canShow;
 }
 
-onMounted((): void => {
-  resultsTotalLength.value = defaultList.value.length;
-  resultsLength.value = lazyOffset;
-});
+// The lists are fetched asynchronously, so seed the counts whenever the data
+// lands rather than only on mount, when it is usually still empty.
+watch(
+  defaultList,
+  (newList: TList[]): void => {
+    resultsTotalLength.value = newList.length;
+    resultsLength.value = Math.min(lazyOffset, newList.length);
+  },
+  { immediate: true }
+);
 </script>
 
 <style lang="scss" scoped>

--- a/docs/.vitepress/theme/components/DownloadSorter.vue
+++ b/docs/.vitepress/theme/components/DownloadSorter.vue
@@ -105,7 +105,7 @@
   </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, watch } from 'vue';
 import { dataSearch, dataFilter, dataSort, formatType } from '../helpers';
 import type { TList } from '../types';
 
@@ -136,6 +136,14 @@ const timeout = ref<any>(null);
 onMounted((): void => {
   onHandleChange(null);
 });
+
+// Re-apply the current search/filters once the fetched list arrives.
+watch(
+  () => props.list,
+  (): void => {
+    onHandleChange(null);
+  }
+);
 
 const emitNewData = (data: TList[], counts: number[]): void => {
   emit('updateData', data);


### PR DESCRIPTION
Fixes #709

## Problem

`DownloadList.vue` used one condition to represent two different states:

```pug
div(v-if="resultsTotalLength === 0")
  p.results-message Loading...
```

`resultsTotalLength` starts at 0 and is *also* 0 when a search matches nothing, so filtering All Sets or All Decks by something like "blah blah blah" left the page stuck on "Loading..." forever.

## Changes

- Loading is now derived from the fetched data itself (`isLoading = defaultList.length === 0`), and an empty result set gets its own `No results found.` message.
- Counts are seeded by a `watch` on `defaultList` with `immediate: true` rather than `onMounted`. `SetList`/`DeckList` are fetched in `Layout.vue`'s `onMounted`, so the old hook read an empty array on every load.
- `DownloadSorter.vue` watches `props.list` and re-applies the active search/filters when the data lands. Its only prior `onHandleChange` call was a 300ms timeout fired at mount, which raced the API response.

## Testing

`eslint` clean on both components, `vitepress build` succeeds, and the jest suite passes (26 tests). The interaction itself was not driven in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xba7S7uYsrKAVdniqNcfhS