### PR TITLE
Document sourceProducts as a Source Products object on Deck and Token cards

### DIFF
--- a/docs/data-models/card/card-deck/index.md
+++ b/docs/data-models/card/card-deck/index.md
@@ -575,9 +575,9 @@ The Card (Deck) Data Model describes the properties of a single card found in a 
 
 > ### sourceProducts <DocBadge type="warning" text="optional" />
 >
-> A list of associated Sealed Product `uuid` properties where this card can be found in.
+> The source product identifiers linked to a [Sealed Product](/data-models/sealed-product/). See the [Source Products](/data-models/source-products/) Data Model.
 >
-> - **Type:** `string[]`
+> - **Type:** `SourceProducts`
 > - **Introduced:** `v5.2.2`
 
 > ### subsets <DocBadge type="warning" text="optional" />

--- a/docs/data-models/card/card-token/index.md
+++ b/docs/data-models/card/card-token/index.md
@@ -373,9 +373,9 @@ The Card (Token) Data Model describes the properties of a single token card foun
 
 > ### sourceProducts <DocBadge type="warning" text="optional" />
 >
-> A list of associated Sealed Product `uuid` properties where this card can be found in.
+> The source product identifiers linked to a [Sealed Product](/data-models/sealed-product/). See the [Source Products](/data-models/source-products/) Data Model.
 >
-> - **Type:** `string[]`
+> - **Type:** `SourceProducts`
 > - **Introduced:** `v5.2.2`
 
 > ### subsets <DocBadge type="warning" text="optional" />

--- a/docs/data-models/source-products/index.md
+++ b/docs/data-models/source-products/index.md
@@ -19,7 +19,7 @@ head:
 
 The Source Products Data Model describes the uuids for the card version in a Sealed Product.
 
-- **Parent model:** [Card (Set)](/data-models/card/card-set/)
+- **Parent model:** [Card (Deck)](/data-models/card/card-deck/), [Card (Set)](/data-models/card/card-set/), [Card (Token)](/data-models/card/card-token/)
 - **Parent property:** `sourceProducts`
 
 ## TypeScript Model


### PR DESCRIPTION
Fixes #642

Card (Deck) and Card (Token) still described `sourceProducts` as a flat `string[]` of Sealed Product uuids. It is actually the same `SourceProducts` object already documented on Card (Set) — a mapping of finish (`etched`, `foil`, `nonfoil`) to the uuids of the products that finish is found in. #632 fixed Card (Set) when it addressed #626–628, but left the identical field on the other two models untouched.

Verified two ways:

- In the data, every card in `AzaarLichlord_PAST.json` (the reporter's example) carries `sourceProducts` as an object like `{"nonfoil": [...]}`, never a flat array.
- Upstream in `mtgjson5/models/cards.py`, `CardSet`, `CardDeck` and `CardToken` all declare `source_products: SourceProducts | None`. The Deck and Token fields just carry a stale `json_schema_extra={"type_override": "string[]"}` and the old description, which is why the generated docs came out wrong — Card (Set) has no such override.

Also lists Card (Deck) and Card (Token) as parent models on the Source Products page, matching how Identifiers and SKU IDs name every parent.

`npm run generate:types` now emits `sourceProducts?: SourceProducts` in `CardDeck.ts` and `CardToken.ts`, in line with `CardSet.ts`. markdownlint is clean on all three changed files.

The other half of #642 — that Source Products' own fields are documented as required but are often absent — was handled by #732.

Note: the root cause is upstream in mtgjson/mtgjson. Until the `type_override` is dropped from `CardDeck.source_products` and `CardToken.source_products` there, the next `--generate-docs` run will overwrite this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xba7S7uYsrKAVdniqNcfhS