### PR TITLE
Document how to call the GraphQL API outside the playground

### DIFF
--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -149,6 +149,21 @@ Here are some common questions about MTGJSON data and services.
 >
 > Additionally, when using MTGGraphQL, our GraphQL API layer, we offer a [NPM TypeScript Package](https://www.npmjs.com/package/mtggraphql/) that exports Types that the GraphQL service uses.
 
+> ### How do I query the GraphQL API?
+>
+> [MTGGraphQL](/mtggraphql/) accepts `POST` requests at `https://graphql.mtgjson.com/`, with your access token in an `authorization` header. Here is a complete request:
+>
+> ```sh
+> curl https://graphql.mtgjson.com/ \
+>   -H 'content-type: application/json' \
+>   -H 'authorization: Bearer <Access Token>' \
+>   -d '{"query": "query { cards(filter: { name_eq: \"Phelddagrif\" }, page: { take: 100, skip: 0 }) { name setCode type } }"}'
+> ```
+>
+> Access tokens are issued to <a href="https://www.patreon.com/MTGJSON" class="link-inline-image patreon" target="_blank" rel="noreferrer noopener">Patreon</a> subscribers while the service is in beta - subscribe, then ask us for a token on [Discord](https://mtgjson.com/discord).
+>
+> See the [MTGGraphQL](/mtggraphql/#usage) documentation for rate limits, more examples, and a playground you can experiment in.
+
 > ### Why is a file/website out of date?
 >
 > You have probably received a cached version of the file or website. If are using a browser, try hard&#8209;refreshing the page (`CTRL + F5` on Windows, `Shift + Command + R` on MacOS).

--- a/docs/mtggraphql/index.md
+++ b/docs/mtggraphql/index.md
@@ -34,6 +34,30 @@ The beta rollout of the service will be available to all <a href="https://www.pa
 
 ## Usage
 
+### Endpoint
+
+Every query is a `POST` request to a single endpoint:
+
+- `https://graphql.mtgjson.com/`
+
+The request body is JSON containing a `query` property, and the response is JSON containing a `data` property. Visiting the endpoint in a browser loads the [GraphQL Playground](#graphql-playground) instead.
+
+### Authorization
+
+Send your access token in an `authorization` header on every request:
+
+```JSON
+{
+  "authorization": "Bearer <Access Token>"
+}
+```
+
+Access tokens are issued to <a href="https://www.patreon.com/MTGJSON" class="link-inline-image patreon" target="_blank" rel="noreferrer noopener">Patreon</a> subscribers while the service is in beta. To get one:
+
+1. Subscribe to MTGJSON on <a href="https://www.patreon.com/MTGJSON" class="link-inline-image patreon" target="_blank" rel="noreferrer noopener">Patreon</a>.
+2. Join our [Discord](https://mtgjson.com/discord).
+3. Ask us for an access token, and we will issue one for your account.
+
 ### Data Source
 
 MTGGraphQL is based on the latest MTGJSON release. For the timings of data updates, see [this FAQ question](/faq/#how-often-is-the-data-updated).
@@ -41,6 +65,40 @@ MTGGraphQL is based on the latest MTGJSON release. For the timings of data updat
 ### Rate Limits
 
 The current rate limits are capped at `1,000` requests per IP Address per hour and `500` requests per access token per hour.
+
+### Querying Outside of the Playground
+
+Any HTTP client can talk to the endpoint. Here is the same query using `curl`:
+
+```sh
+curl https://graphql.mtgjson.com/ \
+  -H 'content-type: application/json' \
+  -H 'authorization: Bearer <Access Token>' \
+  -d '{"query": "query { cards(filter: { name_eq: \"Phelddagrif\" }, page: { take: 100, skip: 0 }) { name setCode type } }"}'
+```
+
+And the same query from JavaScript or TypeScript:
+
+```TypeScript
+const response = await fetch('https://graphql.mtgjson.com/', {
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+    authorization: 'Bearer <Access Token>',
+  },
+  body: JSON.stringify({
+    query: `query {
+      cards(filter: { name_eq: "Phelddagrif" }, page: { take: 100, skip: 0 }) {
+        name
+        setCode
+        type
+      }
+    }`,
+  }),
+});
+
+const { data } = await response.json();
+```
 
 ### NPM TypeScript Package
 
@@ -86,7 +144,7 @@ query {
 
 #### Example HTTP Headers Authorization
 
-Your access token is used here for authorization to the GraphQL API. If you do not have an access token and have subscribed to our <a href="https://www.patreon.com/MTGJSON" class="link-inline-image patreon" target="_blank" rel="noreferrer noopener">Patreon</a>, contact us on [Discord](https://mtgjson.com/discord).
+Paste your access token into the `HTTP HEADERS` tab so the playground can authorize your query. See [Authorization](#authorization) if you do not have a token yet.
 
 ```JSON
 {


### PR DESCRIPTION
Closes #665

The reporter could not find how to query MTGGraphQL from their own code, or how to obtain the access token the playground asks for. The page documented the playground and mentioned a `Bearer` token in a subsection under it, with no endpoint URL and no path to getting a token.

### `docs/mtggraphql/index.md`

- **Endpoint** — `POST https://graphql.mtgjson.com/`, JSON body with a `query` property, and a note that opening it in a browser loads the playground.
- **Authorization** — promoted out of the playground subsection, with numbered steps for obtaining a token (Patreon, then ask on Discord).
- **Querying Outside of the Playground** — a `curl` invocation and a `fetch` example. The curl command was run verbatim against the live endpoint and returns both Phelddagrif printings.
- The playground's auth subsection now links to `#authorization` instead of repeating the "contact us" line.

### `docs/faq/index.md`

New entry, "How do I query the GraphQL API?", carrying the curl example and the token path and linking to `/mtggraphql/#usage`.

`markdownlint` passes and the site builds with no dead links.

One thing to flag: the endpoint currently answers unauthenticated requests, prices included. These docs say to send a token, which matches the intended policy, but anyone testing will find it works without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xba7S7uYsrKAVdniqNcfhS